### PR TITLE
fixed no resource crashing dashboard

### DIFF
--- a/client/agora/views/dashboard/partials/gallery/note-gallery.ejs
+++ b/client/agora/views/dashboard/partials/gallery/note-gallery.ejs
@@ -89,7 +89,7 @@
                 <div class="row ">
                   <div class="col mb-3 gallery-col align-items-stretch">
                     <div class="card h-100" data-toggle="modal" data-target="#create-resource-modal"
-                      onclick='updateResourceModal(<%- availableResources[i].id %>, "<%- process.env.RESOURCE_IMAGE_WEB_PATH %>");'>
+                     >
                       <div class="card-body d-flex flex-column" style="margin-top: 8%">
                         <img src="/assets/img/buttons/new-content.png" class="mx-auto d-block btn-add-content"
                           alt="Add content">


### PR DESCRIPTION
When the add button was being rendered on dashboard it had a onclick event that was only made for resource cards not the add button causing it crash as their were no id's available. Removed the event and everything is function properly .