### PR TITLE
Fixed Dashboard wysiwyg 

### DIFF
--- a/client/agora/views/dashboard/partials/gallery/note-gallery.ejs
+++ b/client/agora/views/dashboard/partials/gallery/note-gallery.ejs
@@ -112,7 +112,7 @@
 
 
 
-              <%- include('../../../partials/jsincludes.ejs'); %>
+             
 
                 <script>
                   $('.dropdown-content').on('click', function (ev) {


### PR DESCRIPTION
The note-gallery file was including the include('../../../partials/jsincludes.ejs') in a redundant matter which was causing issues with the initialization of the sun editor. As seen in issues #161 
<img width="1334" alt="image" src="https://user-images.githubusercontent.com/55935877/192908179-022028dc-468a-4acc-8d9e-9619b38f2b89.png">
