### PR TITLE
Update Image Bug Fix

### DIFF
--- a/server/controller/apis/goalController.js
+++ b/server/controller/apis/goalController.js
@@ -197,7 +197,7 @@ exports.saveGoal = async ( req, res, redirect ) =>{
         /**
          * Once the goal is saved, save the image if it is passed in the multipart form data
          */
-        if ( req.body.goalModified && req.body.goalModified != "false" && !req.files ) {
+        if ( req.body.goalModified && !req.files ) {
             // do nothing we are going to keep the original file
             console.log("goal trigger modification clause");
         }

--- a/server/controller/apis/resourceController.js
+++ b/server/controller/apis/resourceController.js
@@ -283,7 +283,7 @@ exports.saveResource = async ( req, res, redirect ) => {
          */ 
 
         // The UI needs to verify modifiction so that the image is not dropped if the user does not want to change it
-        if ( req.body.resourceModified && req.body.resourceModified != "false" && !req.files ) {
+        if ( req.body.resourceModified && !req.files ) {
             // do nothing we are going to keep the original file
             console.log("resource trigger modification clause");
         }

--- a/server/controller/apis/topicController.js
+++ b/server/controller/apis/topicController.js
@@ -310,7 +310,7 @@ exports.saveTopic = async ( req, res, redirect ) => {
          */ 
 
         // The UI needs to verify modifiction so that the image is not dropped if the user does not want to change it
-        if ( req.body.topicModified && req.body.topicModified != "false" && !req.files ) {
+        if ( req.body.topicModified && !req.files ) {
             // do nothing we are going to keep the original file
             console.log("topic trigger modification clause");
         }


### PR DESCRIPTION
This solves our updateImage bug that we were running into. 

Comment from old PR:

After our discussion post class on Monday, we discussed the three cases when saving an image while updating an entity (New entity with no image passed, existing entity with no image passed, existing/new entity with an image passed). The error within our backend code was located within the most common case (Existing entity with no image passed). This would cause the image to be deleted and replaced with the default image. I noticed a weird redundancy in the if statement for this case which caused it to never be true. I have decided to close this PR out and create a new one with this simple change. 
This change works perfectly through the front end, but we have no idea how to test it through the backend due to the <entity>Modified field being located in the front end. If anyone has an idea of how to do this using Thunder Client it would be appreciated if you could share it amongst the team in the discord. I believe this is a good stopping point for this issue in Milestone 2. We will most likely have to revisit saving images once we decided on how to save an image using a pure API call. 