### PR TITLE
update fields on topic page from backend and small dashboard changes

### DIFF
--- a/client/agora/public/js/dashboard.js
+++ b/client/agora/public/js/dashboard.js
@@ -697,8 +697,8 @@ var cards = document.querySelectorAll( "#rename-card" ).forEach( ( card ) => {
 
 //changing the properties of the save button of the rename-modal depending on the selected card
 const updateSaveButton = ( nameId, descId, prefix ) => {
-    let name = document.getElementById( "note-modal-name" ).value;
-    let desc = document.getElementById( "note-modal-description" ).value;
+    let name = (document.getElementById( "note-modal-name" ).value).trim();
+    let desc = (document.getElementById( "note-modal-description" ).value).trim();
     if ( name ) {
         document.getElementById( prefix + "gv-" + nameId ).innerText = name;
         document.getElementById( prefix + "lv-" + nameId ).innerText = name;
@@ -746,7 +746,7 @@ const showDeleteModal = ( e ) => {
     let parentName = document.getElementById( parentNameId ).innerText;
 
     //setting the text inside the delete modal to show user what they're deleting
-    document.getElementById( "to-be-deleted-name" ).innerText = parentName;
+    document.getElementById( "to-be-deleted-name" ).innerText = parentName.trim();
 
     //setting the properties of the confirm button to delete the correct card
     document
@@ -805,6 +805,11 @@ const topicReroute = ( id, newTab, prefix ) => {
         window.open( "http://localhost:4200/topic#" + usedPrefix + id, "_blank" );
     }
     else {
+        /*if (usedPrefix === "-t") {
+            window.location.href = "/topic#" + usedPrefix + id.substring( 5 );
+        } else {
+            window.location.href = "/goal#" + usedPrefix + id.substring( 5 );
+        }*/
         window.location.href = "/topic#" + usedPrefix + id.substring( 5 );
     }
 };
@@ -940,7 +945,7 @@ const duplicateGoal = ( e ) => {
 
     getTopics();
 
-    createToast( "Duplicated " + nameOfClone );
+    createToast( "Duplicated " + nameOfClone.trim() );
 
     e.stopPropagation();
         

--- a/client/agora/public/js/dashboard.js
+++ b/client/agora/public/js/dashboard.js
@@ -463,7 +463,7 @@ const createNewGoal = async () => {
 
 //edit is a number if editing a resource, false if adding a resource
 //prefix indicates whether card is goal or topic
-const addOrEditResource = ( prefix, name, description, edit ) => {
+const duplicateOrEditResource = ( prefix, name, description, edit ) => {
     let id = -1;
     if ( edit ) {
         id = edit;
@@ -485,7 +485,9 @@ const addOrEditResource = ( prefix, name, description, edit ) => {
             } )
         } )
             .then( response => response.json() )
-            .then( response => console.log( JSON.stringify( response ) ) );
+            .then( response => {
+                return response.id;
+            } );
     //if topic
     } 
     else {
@@ -508,7 +510,9 @@ const addOrEditResource = ( prefix, name, description, edit ) => {
             } )
         } )
             .then( response => response.json() )
-            .then( response => console.log( JSON.stringify( response ) ) );
+            .then( response => {
+                return response.id;
+            } );
     }
 };
 
@@ -704,7 +708,7 @@ const updateSaveButton = ( nameId, descId, prefix ) => {
         document.getElementById( prefix + "lv-" + nameId ).innerText = name;
         document.getElementById( prefix + "gv-" + descId ).innerText = desc;    
 
-        addOrEditResource( prefix, name, desc, descId.substring( 10 ) );
+        duplicateOrEditResource( prefix, name, desc, descId.substring( 10 ) );
 
         closeRenameModal();
     }
@@ -859,7 +863,7 @@ var newTabCards = document
 ////////*Handling Duplicate*/////////////
 
 //handles cloning a card then updating it's id and properties
-const duplicateGoal = ( e ) => {
+const duplicateGoal = async ( e ) => {
   
     let parentId = getId( e );
    
@@ -874,12 +878,11 @@ const duplicateGoal = ( e ) => {
     let listClone = listParent.cloneNode( true );
    
     //getting the next id to use
-    let newId = checkForNextId();
 
     let nameOfClone = gridParent.childNodes[1].childNodes[3].childNodes[1].innerText;
     
     //fetch call to update backend
-    addOrEditResource( prefix, nameOfClone, gridParent.childNodes[1].childNodes[3].childNodes[3].innerText, null );
+    const newId = await duplicateOrEditResource( prefix, nameOfClone, gridParent.childNodes[1].childNodes[3].childNodes[3].innerText, null );
 
     //changing the ids in the cloned element
     gridClone = replaceIds( gridClone, newId, true, prefix );
@@ -969,44 +972,6 @@ const placeElement = (gridElement, listElement, gridContainer, listContainer, pr
         listContainer.insertBefore(listElement, listContainer.querySelector( ".a-topic" ));
     }
 }
-
-//Calculating the id of a new card
-const checkForNextId = () => {
-    var ids = [];
-    document.querySelectorAll( ".countable" ).forEach( ( obj ) => {
-        let temp = obj.id.split( "-" ).pop();
-        ids.push( temp );
-    } );
-    ids.sort();
-
-    const len = ids.length;
-    var done = false;
-    var iterator = 1;
-    var output = 0;
-    if ( ids[0] > 0 ) {
-        output = 0;
-        done = true;
-    }
-    else if ( len === 1 ) {
-        output = ++ids[0];
-        done = true;
-    }
-    else {
-        while ( !done && len > iterator ) {
-            if ( ids[iterator] - ids[iterator - 1] > 1 ) {
-                done = true;
-                output = ++ids[iterator - 1];
-            }
-            else {
-                iterator++;
-            }
-        }
-    }
-    if ( !done ) {
-        output = ++ids[len - 1];
-    }
-    return output;
-};
 
 //handles updating an element's various ids
 const replaceIds = ( element, newId, grid, prefix ) => {

--- a/client/agora/public/js/dashboard.js
+++ b/client/agora/public/js/dashboard.js
@@ -455,7 +455,7 @@ const createNewGoal = async () => {
         } )
     } )
         .then( response => response.json() )
-        .then( response => window.location.href = "/topic#g-" + response.id );
+        .then( response => window.location.href = "/topic#g-" + response.goalId );
 };
 
 

--- a/client/agora/public/js/dashboard.js
+++ b/client/agora/public/js/dashboard.js
@@ -853,7 +853,7 @@ const copyLink = ( e ) => {
 };
 
 
-var newTabCards = document
+var copyLinkCards = document
     .querySelectorAll( "#copy-link-card" )
     .forEach( ( copyLinkCard ) => {
         copyLinkCard.addEventListener( "click", copyLink );

--- a/client/agora/public/js/dashboard.js
+++ b/client/agora/public/js/dashboard.js
@@ -1025,7 +1025,10 @@ const getTopics = () => {
     topicArr = document.querySelectorAll( '.query-countable' );
 };
 
-window.onload = getTopics;
+window.addEventListener( 'load', () => {
+    getTopics();
+    toggleGrid();
+})
 
 //what changes the DOM and modifies removed topics depending on search
 //newVal is the input value
@@ -1130,5 +1133,3 @@ const toggleList = () => {
     document.getElementById( "main-container" ).appendChild( document.getElementById( "list-container" ) );
     document.getElementById( "list-container" ).style.display = "block";
 };
-
-window.onload( toggleGrid() );

--- a/client/agora/public/js/dashboard.js
+++ b/client/agora/public/js/dashboard.js
@@ -937,11 +937,10 @@ const duplicateGoal = ( e ) => {
     //makes the ellipsis of the clone hidden on initialization
     gridClone.childNodes[1].childNodes[1].style.visibility = "hidden";
 
-    //adding the new clone to the grid container
-    document.getElementById( "gallery-row" ).insertBefore( gridClone, gridParent.nextSibling );
-
-    //adding the new clone to the list container
-    document.getElementById( "list-column" ).insertBefore( listClone, listParent.nextSibling );
+    //adding element to dom
+    const gridContainer = document.getElementById( "gallery-row" );
+    const listContainer = document.getElementById( "list-column" );
+    placeElement(gridClone, listClone, gridContainer, listContainer, prefix);
 
     getTopics();
 
@@ -957,6 +956,19 @@ var duplicateCards = document
     .forEach( ( duplicateCard ) => {
         duplicateCard.addEventListener( "click", duplicateGoal );
     } );
+
+
+const placeElement = (gridElement, listElement, gridContainer, listContainer, prefix) => {
+    if ( prefix === "g-" ) {
+        gridContainer.insertBefore(gridElement, gridContainer.childNodes[2]);
+
+        listContainer.insertBefore(listElement, listContainer.childNodes[2]);
+    } else {
+        gridContainer.insertBefore(gridElement, gridContainer.querySelector( ".a-topic" ));
+
+        listContainer.insertBefore(listElement, listContainer.querySelector( ".a-topic" ));
+    }
+}
 
 //Calculating the id of a new card
 const checkForNextId = () => {

--- a/client/agora/public/js/dashboard.js
+++ b/client/agora/public/js/dashboard.js
@@ -420,7 +420,6 @@ function updateResourceModal( resourceId, resourceImagePath ) {
 }
 
 
-
 //creates a empty topic
 const createNewTopic = async () => {
     
@@ -438,14 +437,6 @@ const createNewTopic = async () => {
     } )
         .then( response => response.json() )
         .then( response => window.location.href = "/topic#t-" + response.topicId );
-
-     
-    
-
-
-    //gets the most recent id
-    //let id = temp[temp.length - 1].topicId;
-    // window.location.href = '/topic#t-' + id;
 };
 
 //creates a empty topic
@@ -465,8 +456,6 @@ const createNewGoal = async () => {
     } )
         .then( response => response.json() )
         .then( response => window.location.href = "/topic#g-" + response.id );
-   
-  
 };
 
 
@@ -813,10 +802,10 @@ const topicReroute = ( id, newTab, prefix ) => {
 
     //pass the title and description to backend
     if ( newTab ) {
-        window.open( "http://localhost:4200/topic", "_blank" );
+        window.open( "http://localhost:4200/topic#" + usedPrefix + id, "_blank" );
     }
     else {
-        window.location.href = "/topic#t-" + id.substring( 5 ) ;
+        window.location.href = "/topic#" + usedPrefix + id.substring( 5 );
     }
 };
 

--- a/client/agora/public/js/dashboard.js
+++ b/client/agora/public/js/dashboard.js
@@ -838,24 +838,24 @@ var newTabCards = document
 const copyLink = ( e ) => {
     let parentId = getId( e );
 
-    navigator.clipboard.writeText( "http://localhost:4200/note" );
+    let prefix;
+    isTopic( e ) ? prefix = "t-" : prefix = "g-";
+
+    navigator.clipboard.writeText( "http://localhost:4200/topic#" + prefix + parentId );
 
     createToast( "Copied Link!" );
 
     e.stopPropagation();
 };
 
-/**
- * This function was caught by ESLint as a duplicate function.
- * I am not sure why it is here, but I am leaving it here for now.
- * I do not see any calls to this function anywhere in the code. 
- *
+
 var newTabCards = document
     .querySelectorAll( "#copy-link-card" )
     .forEach( ( copyLinkCard ) => {
         copyLinkCard.addEventListener( "click", copyLink );
     } );
-*/
+
+
 ////////*Handling Duplicate*/////////////
 
 //handles cloning a card then updating it's id and properties

--- a/client/agora/public/js/dashboard.js
+++ b/client/agora/public/js/dashboard.js
@@ -445,7 +445,7 @@ const createNewTopic = async () => {
 
     //gets the most recent id
     //let id = temp[temp.length - 1].topicId;
-   // window.location.href = '/topic#t-' + id;
+    // window.location.href = '/topic#t-' + id;
 };
 
 //creates a empty topic
@@ -816,7 +816,7 @@ const topicReroute = ( id, newTab, prefix ) => {
         window.open( "http://localhost:4200/topic", "_blank" );
     }
     else {
-        window.location.href = "/topic#t-" + id.substring(5) ;
+        window.location.href = "/topic#t-" + id.substring( 5 ) ;
     }
 };
 

--- a/client/agora/public/js/topic.js
+++ b/client/agora/public/js/topic.js
@@ -827,38 +827,39 @@ const idPattern = /-([0-9]+)/;
 const idAndFetch = () => {
 
     const url = window.location.href;
-    const id = idPattern.exec(url)[1];
-    const isTopic = prefixPattern.test(url);
+    const id = idPattern.exec( url )[1];
+    const isTopic = prefixPattern.test( url );
 
-    if (isTopic) {
+    if ( isTopic ) {
         fetch( "api/v1/auth/topics/" + id, {
             method: "GET",
             headers: { 'Content-Type': 'application/json' },
         } )
             .then( response => response.json() )
             .then( response => {
-                fillFields(response.topicName, response.topicDescription, response.topicImage);
-            });
-    } else {
+                fillFields( response.topicName, response.topicDescription, response.topicImage );
+            } );
+    } 
+    else {
         fetch( "api/v1/auth/goals/" + id, {
             method: "GET",
             headers: { 'Content-Type': 'application/json' },
         } )
             .then( response => response.json() )
             .then( response => {
-                fillFields(response.goalName, response.goalDescription, response.goalImage);
-            });
+                fillFields( response.goalName, response.goalDescription, response.goalImage );
+            } );
     }
-}
+};
 
-const fillFields = (title, description, image) => {
-    document.getElementById("workspace-title").value = title.trim();
-    document.getElementById("workspace-desc").value = description.trim();
-}
+const fillFields = ( title, description, image ) => {
+    document.getElementById( "workspace-title" ).value = title.trim();
+    document.getElementById( "workspace-desc" ).value = description.trim();
+};
 
 window.addEventListener( 'load', () => {
     idAndFetch();
-});
+} );
 
 
 

--- a/client/agora/public/js/topic.js
+++ b/client/agora/public/js/topic.js
@@ -5,6 +5,8 @@
  * see included LICENSE or https://opensource.org/licenses/BSD-3-Clause 
  */
 
+//const { ConfigurationServicePlaceholders } = require("aws-sdk/lib/config_service_placeholders");
+
 
 // keep track of running total of new questions for assessment
 let newQuestionNum = 0;
@@ -815,4 +817,52 @@ function updateTopicResourceCompleteStatus( resourceId, submittedText ) {
     } ).then( ( res ) => {
     } );
 }
+
+//////////////onload fetch functions //////////////////////
+
+const prefixPattern = /#t/;
+
+const idPattern = /-([0-9]+)/;
+
+const idAndFetch = () => {
+
+    const url = window.location.href;
+    const id = idPattern.exec(url)[1];
+    const isTopic = prefixPattern.test(url);
+
+    if (isTopic) {
+        fetch( "api/v1/auth/topics/" + id, {
+            method: "GET",
+            headers: { 'Content-Type': 'application/json' },
+        } )
+            .then( response => response.json() )
+            .then( response => {
+                fillFields(response.topicName, response.topicDescription, response.topicImage);
+            });
+    } else {
+        fetch( "api/v1/auth/goals/" + id, {
+            method: "GET",
+            headers: { 'Content-Type': 'application/json' },
+        } )
+            .then( response => response.json() )
+            .then( response => {
+                fillFields(response.goalName, response.goalDescription, response.goalImage);
+            });
+    }
+}
+
+const fillFields = (title, description, image) => {
+    document.getElementById("workspace-title").value = title;
+    document.getElementById("workspace-desc").value = description;
+}
+
+window.addEventListener( 'load', () => {
+    idAndFetch();
+});
+
+
+
+
+
+
 

--- a/client/agora/public/js/topic.js
+++ b/client/agora/public/js/topic.js
@@ -852,8 +852,8 @@ const idAndFetch = () => {
 }
 
 const fillFields = (title, description, image) => {
-    document.getElementById("workspace-title").value = title;
-    document.getElementById("workspace-desc").value = description;
+    document.getElementById("workspace-title").value = title.trim();
+    document.getElementById("workspace-desc").value = description.trim();
 }
 
 window.addEventListener( 'load', () => {

--- a/client/agora/views/dashboard/partials/gallery/grid-template.ejs
+++ b/client/agora/views/dashboard/partials/gallery/grid-template.ejs
@@ -86,7 +86,7 @@
          //render goals
             
          for (let i = 0; i <  ownerGoals.length ; i++) { 
-            renderCard(ownerGoals[i].id,ownerGoals[i].goalName,ownerGoals[i].goalDescription,["Bio","Chem"],"Goal", ["Doc1","doc2"]) 
+            renderCard(ownerGoals[i].goalId,ownerGoals[i].goalName,ownerGoals[i].goalDescription,["Bio","Chem"],"Goal", ["Doc1","doc2"]) 
          }%>
             <% //render resources for Now
         for (let i = 0; i <  ownerTopics.length ; i++) { 

--- a/client/agora/views/dashboard/partials/gallery/grid-template.ejs
+++ b/client/agora/views/dashboard/partials/gallery/grid-template.ejs
@@ -5,7 +5,7 @@
 
         <!--Topic Card -->
         <div class="col mb-3 align-items-stretch gallery-col query-countable view-check">
-          <div class="card h-100 countable" id="t-gv-<%= id %>" onmouseover="toggleMoreOptionsOn(id)" onmouseout="toggleMoreOptionsOff(id)" onclick="topicReroute(id, false)">
+          <div class="card h-100 countable" id="t-gv-<%= id %>" onmouseover="toggleMoreOptionsOn(id)" onmouseout="toggleMoreOptionsOff(id)" onclick="topicReroute(id, false, null)">
             <div class="dropdown dropbtn trigger1 trigger2 grid-options" id="t-gv-option-<%= id %>" style="visibility: hidden">
               <img src="/assets/img/buttons/more-options.png" class="dropbtn"/>
               <%- include('./dropdown.ejs'); %>
@@ -49,7 +49,7 @@
                   <ul class="list-group list-group-flush list-grid">
                     <% content.slice(0,8).forEach((item) => { %>
                       <!--topicReroute() below has a filler id-->
-                      <li class="list-group-item item-list" title='Open <%=item%>' onclick="topicReroute(1, false)"> <span class="material-icons document-icon" >&nbsp;description</span><span class="item-list-text"><%= item %></span></li>
+                      <li class="list-group-item item-list" title='Open <%=item%>' onclick="topicReroute(1, false, null)"> <span class="material-icons document-icon" >&nbsp;description</span><span class="item-list-text"><%= item %></span></li>
                     <% }) %>
                   </ul>
                 <% } %>

--- a/client/agora/views/dashboard/partials/gallery/grid-template.ejs
+++ b/client/agora/views/dashboard/partials/gallery/grid-template.ejs
@@ -4,7 +4,7 @@
       if (contentType === "Topic") { %>
 
         <!--Topic Card -->
-        <div class="col mb-3 align-items-stretch gallery-col query-countable view-check">
+        <div class="col mb-3 align-items-stretch gallery-col query-countable view-check a-topic">
           <div class="card h-100 countable" id="t-gv-<%= id %>" onmouseover="toggleMoreOptionsOn(id)" onmouseout="toggleMoreOptionsOff(id)" onclick="topicReroute(id, false, null)">
             <div class="dropdown dropbtn trigger1 trigger2 grid-options" id="t-gv-option-<%= id %>" style="visibility: hidden">
               <img src="/assets/img/buttons/more-options.png" class="dropbtn"/>

--- a/client/agora/views/dashboard/partials/gallery/grid-template.ejs
+++ b/client/agora/views/dashboard/partials/gallery/grid-template.ejs
@@ -5,7 +5,7 @@
 
         <!--Topic Card -->
         <div class="col mb-3 align-items-stretch gallery-col query-countable view-check a-topic">
-          <div class="card h-100 countable" id="t-gv-<%= id %>" onmouseover="toggleMoreOptionsOn(id)" onmouseout="toggleMoreOptionsOff(id)" onclick="topicReroute(id, false, null)">
+          <div class="card h-100" id="t-gv-<%= id %>" onmouseover="toggleMoreOptionsOn(id)" onmouseout="toggleMoreOptionsOff(id)" onclick="topicReroute(id, false, null)">
             <div class="dropdown dropbtn trigger1 trigger2 grid-options" id="t-gv-option-<%= id %>" style="visibility: hidden">
               <img src="/assets/img/buttons/more-options.png" class="dropbtn"/>
               <%- include('./dropdown.ejs'); %>
@@ -34,7 +34,7 @@
 
         <!--Goal Card-->
         <div class="col mb-3 align-items-stretch gallery-col query-countable view-check a-goal">
-          <div class="card h-100 countable" id="g-gv-<%= id %>" onmouseover="toggleMoreOptionsOn(id)" onmouseout="toggleMoreOptionsOff(id)" onclick="topicReroute(id, false, null)">
+          <div class="card h-100" id="g-gv-<%= id %>" onmouseover="toggleMoreOptionsOn(id)" onmouseout="toggleMoreOptionsOff(id)" onclick="topicReroute(id, false, null)">
             <div class="dropdown dropbtn trigger1 trigger2 grid-options" id="g-gv-option-<%= id %>" style="visibility: hidden">
               <img src="/assets/img/buttons/more-options.png" class="dropbtn"/>
               <%- include('./dropdown.ejs'); %>

--- a/client/agora/views/dashboard/partials/gallery/grid-template.ejs
+++ b/client/agora/views/dashboard/partials/gallery/grid-template.ejs
@@ -34,7 +34,7 @@
 
         <!--Goal Card-->
         <div class="col mb-3 align-items-stretch gallery-col query-countable view-check a-goal">
-          <div class="card h-100 countable" id="g-gv-<%= id %>" onmouseover="toggleMoreOptionsOn(id)" onmouseout="toggleMoreOptionsOff(id)">
+          <div class="card h-100 countable" id="g-gv-<%= id %>" onmouseover="toggleMoreOptionsOn(id)" onmouseout="toggleMoreOptionsOff(id)" onclick="topicReroute(id, false, null)">
             <div class="dropdown dropbtn trigger1 trigger2 grid-options" id="g-gv-option-<%= id %>" style="visibility: hidden">
               <img src="/assets/img/buttons/more-options.png" class="dropbtn"/>
               <%- include('./dropdown.ejs'); %>

--- a/client/agora/views/dashboard/partials/gallery/list-template.ejs
+++ b/client/agora/views/dashboard/partials/gallery/list-template.ejs
@@ -52,7 +52,7 @@
         </li>
         <% 
         for (let i = 0; i < ownerGoals.length ; i++) { 
-            renderListCard(ownerGoals[i].id,ownerGoals[i].goalName,ownerGoals[i].goalDescription,["Bio","Chem"],"Goal", ["Doc1","doc2"]) 
+            renderListCard(ownerGoals[i].goalId,ownerGoals[i].goalName,ownerGoals[i].goalDescription,["Bio","Chem"],"Goal", ["Doc1","doc2"]) 
         } 
         for (let i = 0; i <  availableTopics.length ; i++) { 
             renderListCard(ownerTopics[i].topicId,ownerTopics[i].topicName,ownerTopics[i].topicDescription,["Bio","Chem"],"Topic", null); 

--- a/client/agora/views/dashboard/partials/gallery/list-template.ejs
+++ b/client/agora/views/dashboard/partials/gallery/list-template.ejs
@@ -12,7 +12,7 @@
       if (contentType === "Topic") { %>
 
         <!--Topic List Member -->
-        <li class="list-group-item list-view view-check" id="t-lv-<%= id %>" onclick="topicReroute(id, false)">
+        <li class="list-group-item list-view view-check a-topic" id="t-lv-<%= id %>" onclick="topicReroute(id, false)">
             <span id="t-lv-card-title-<%= id %>"><%=name%></span>
             <span class="badge badge-dark note-badge" style="position: absolute; left: 33.1%;"><%=contentType%></span>
             <span style="position: absolute; left: 45.7%"><% showTags(tags) %></span>


### PR DESCRIPTION
-Name and description update on topic page from backend
-Fixed url updating when entering a topic/goal from the dashboard
-Added trimming to dashboard names and descriptions
-changed copy link button in more options menu to copy the correct link
-duplicating a card will add it the beginning of the lists of goals or topics instead of the end (DOM only)
-ids being assigned to cards will occur based on backend response data before page refresh