### PR TITLE
Print uncaught error to console and fix discussion enabling

### DIFF
--- a/server/agora.js
+++ b/server/agora.js
@@ -189,6 +189,7 @@ if ( process.env.GITHUB_TOGGLE == "true" ) {
 }
 
 app.use( ( error, req, res, next ) => {
+    console.error( error );
     return errorController( ApiMessage.createInternalServerError(), res );
 } );
 

--- a/server/service/discussionService.js
+++ b/server/service/discussionService.js
@@ -15,10 +15,10 @@ exports.createDiscussion = async ( type, id, discussion_text, userId ) => {
             discussion_text
         )
         SELECT parent.id, $1, $3
-        FROM $5 parent
+        FROM ${parentTable} parent
         WHERE parent.id = $2 AND parent.owned_by = $4;
     `;
-    const values = [ type, id, userId, discussion_text, parentTable ];
+    const values = [ type, id, userId, discussion_text ];
     
     try {
         


### PR DESCRIPTION
With PR #237 errors stopped being printed to console making development hard. 

Also, we found a bug in the creation of discussions