### PR TITLE
Enable DB connection over SSL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,7 @@ PG_HOST = localhost
 PG_PASSWORD = agora
 PG_DATABASE = agora
 PG_PORT = 5432
+PG_SSL = false
 
 // session secret
 SESSION_SECRET = MAKE_THIS_A_RANDOM_STRING!

--- a/server/db/connection.js
+++ b/server/db/connection.js
@@ -15,7 +15,8 @@ const pool = new Pool( {
     database: process.env.PG_DATABASE,
     max: 20,
     idleTimeoutMillis: 30000,
-    connectionTimeoutMillis: 2000
+    connectionTimeoutMillis: 2000,
+    ssl: process.env.PG_SSL === "true" ? true : false
 } );
 
 


### PR DESCRIPTION
My team has been sharing a database connection that I set up. It is a cloud database so it requires this configuration to connect. For the past weeks, we've been just avoiding committing the connection.js file but I want to do it the right way. 

In class, I mentioned that the database connection could be shared for most use cases, I'd be willing to create a new database for the class to use as the default. This way we could finally get around the upcoming database migrations for each person if they just want to use the shared one. I'm currently using a provider called neon.tech who has a generous free tier.