### PR TITLE
Added Shared Entity tables to DB creation file

### DIFF
--- a/server/db/createTablesScript-base-example.sql
+++ b/server/db/createTablesScript-base-example.sql
@@ -605,3 +605,25 @@ CREATE TABLE IF NOT EXISTS discussion_comment_ratings (
 );
 
 GRANT ALL PRIVILEGES ON TABLE discussion_comment_ratings TO agora;
+
+--   Shared Entity tables
+
+CREATE TABLE IF NOT EXISTS shared_entities (
+    shared_entity_id SERIAL PRIMARY KEY,
+    entity_id INTEGER,          -- unique id number of the entity being shared
+    entity_type INTEGER,        -- type of entity being shared, ENUM value: 1=goal / workspace, 2=topic, 3=resource
+    share_user_id INTEGER,      -- user id of the user who the entity was shared with
+    owner_user_id INTEGER,      -- user id of the user who shared the entity
+    -- share_type INTEGER,      -- type of share, ENUM value: 1=public, 2=shared (Commented out - would a publicly visible item have entries in this table?)
+    permission_level INTEGER,   -- permission level of the shared entity, ENUM value: 1=view, 2=discussion, 3=edit
+    can_copy BOOLEAN,           -- can the shared entity be copied by another user?
+    create_time TIMESTAMP DEFAULT current_timestamp,
+    update_time TIMESTAMP
+);
+GRANT ALL PRIVILEGES ON TABLE shared_entities TO agora;
+GRANT USAGE, SELECT ON SEQUENCE shared_entities_shared_entity_id_seq TO agora;
+
+CREATE INDEX IF NOT EXISTS idx_shared_share_user_id ON shared_entities (share_user_id);
+CREATE INDEX IF NOT EXISTS idx_shared_owner_user_id ON shared_entities (owner_user_id);
+CREATE INDEX IF NOT EXISTS idx_shared_entity_id ON shared_entities (entity_id);
+CREATE INDEX IF NOT EXISTS idx_shared_entity_type ON shared_entities (entity_type);


### PR DESCRIPTION
Added shared_entities table in accordance with the Sharing document from Data Science. We did comment out the share_type field as it seemed redundant to create entries for public items.