### PR TITLE
Workspace route got changed pointing to service layer function rather than controller correct one

### DIFF
--- a/server/routes/apis/workspaceRoutes.js
+++ b/server/routes/apis/workspaceRoutes.js
@@ -37,7 +37,7 @@ router.route( '/' )
 router.route( '/:workspaceId' )
     // get a visible workspace by id
     .get( async ( req, res ) => {
-        workspaceController.getMostRecentWorkspaceById( req, res );
+        workspaceController.getWorkspaceById( req, res );
     
     } )
     // delete a visible workspace by id


### PR DESCRIPTION
The route for GET was pointing to workspaceController.getMostRecentWorkspaceById(which does not exist) rather than getWorkspaceById().(This was the function being called a couple days ago in commits, I think their was a mistype along the way