### PR TITLE
Bugfix topic tabs names becoming untitled on click

### DIFF
--- a/client/agora/public/js/topic-view.js
+++ b/client/agora/public/js/topic-view.js
@@ -130,10 +130,11 @@ function createTopic( name ) {
     topicTitle.className = "topic-title";
     topicTitle.id = "topic-title" + numTopics;
     if( name ){
-        topicTitle.placeholder = name;
+        //topicTitle.placeholder = name;
+        topicTitle.value = name;
     }
     else{
-        topicTitle.placeholder = "Untitled";
+        topicTitle.value = "Untitled";
     }
 
     let saveIcon = document.createElement( "span" );


### PR DESCRIPTION
topics name field was setting placeholder rather than value, so when  value was retrieved it was clearing the field