### PR TITLE
Force getById API calls to validate visibility

### DIFF
--- a/server/controller/apis/topicController.js
+++ b/server/controller/apis/topicController.js
@@ -282,7 +282,7 @@ exports.saveTopic = async ( req, res, redirect ) => {
         topic.topicId = req.body.topicId;
 
         // see if this is a modification of an existing topic
-        let existingTopic = await topicService.getTopicById( topic.topicId, false );
+        let existingTopic = await topicService.getTopicById( topic.topicId, authUserId );
 
         // if this is an update, replace the topic with the existing one as the starting point.
         if( existingTopic ) {

--- a/server/controller/apis/workspaceController.js
+++ b/server/controller/apis/workspaceController.js
@@ -45,21 +45,31 @@ exports.getAllVisibleWorkspaces = async ( req, res ) => {
 };
 
 exports.getWorkspaceById = async ( req, res ) => {
-    // get all the active workspaces by user 
-    let workspace = await workspaceService.getActiveWorkspaceWithTopicsById( req.params.workspaceId, true );
-    if( workspace ) {
-        res.set( "x-agora-message-title", "Success" );
-        res.set( "x-agora-message-detail", "Returned workspace by id" );
-        res.status( 200 ).json( workspace );
+
+    // Get the auth user id from either the basic auth header or the session.
+    let authUserId;
+    if( req.user ) {
+        authUserId = req.user.id;
     }
-    else {
-        const message = ApiMessage.createApiMessage( 404, "Not Found", "Workspace not found" );
-        res.set( "x-agora-message-title", "Not Found" );
-        res.set( "x-agora-message-detail", "Workspace not found" );
-        res.status( 404 ).json( message );
+    else if( req.session.authUser ) {
+        authUserId = req.session.authUser.id;
     }
-    
-    
+
+    if( authUserId > 0 ) {
+        // get all the active workspaces by user
+        let workspace = await workspaceService.getActiveWorkspaceWithTopicsById( req.params.workspaceId, authUserId, true );
+        if ( workspace ) {
+            res.set( "x-agora-message-title", "Success" );
+            res.set( "x-agora-message-detail", "Returned workspace by id" );
+            res.status( 200 ).json( workspace );
+        }
+        else {
+            const message = ApiMessage.createApiMessage( 404, "Not Found", "Workspace not found" );
+            res.set( "x-agora-message-title", "Not Found" );
+            res.set( "x-agora-message-detail", "Workspace not found" );
+            res.status( 404 ).json( message );
+        }
+    }
 };
 
 exports.getAllTopicsForWorkspaceId = async ( req, res ) => {

--- a/server/service/topicService.js
+++ b/server/service/topicService.js
@@ -193,12 +193,13 @@ exports.getAllActiveTopics = async function() {
 
 /**
  * Get a topic by id
- * @param {Integer} topicId 
+ * @param {Integer} topicId
+ * @param {Integer} ownerId - the ID of the requester, used to validate visibility
  * @returns topic
  */
-exports.getTopicById = async function( topicId ) {
-    let text = "SELECT * FROM topics WHERE id = $1";
-    let values = [ topicId ];
+exports.getTopicById = async function( topicId, ownerId ) {
+    let text = "SELECT * FROM topics WHERE id = $1 AND (owned_by = $2 OR visibility = 2)";
+    let values = [ topicId, ownerId ];
     try {
         let topic = "";
          

--- a/server/service/workspaceService.js
+++ b/server/service/workspaceService.js
@@ -158,24 +158,25 @@ exports.getAllWorkspacesForOwner = async ( ownerId, isActive ) => {
 
 /**
  * Get an active workspace by id including associated topics
- * @param {Integer} workspaceId 
+ * @param {Integer} workspaceId
+ * @param {Integer} ownerId - the ID of the requester, used to validate visibility
  * @param {boolean} isActive - if true require that the topic is active to return, false returns all topics both active and in-active.
  * @returns workspace with topics
  */
-exports.getActiveWorkspaceWithTopicsById = async ( workspaceId, isActive ) => {
+exports.getActiveWorkspaceWithTopicsById = async ( workspaceId, ownerId, isActive ) => {
 
     let text = "";
     let values = [];
     if( !isActive ) {
-        text = "select * from goals gl INNER JOIN (SELECT id, MAX(goal_version) AS max_version FROM goals where id = $1 group by id) goalmax "
+        text = "select * from goals gl INNER JOIN (SELECT id, MAX(goal_version) AS max_version FROM goals where id = $1 AND (owned_by = $2 OR visibility = 2) group by id) goalmax "
         + "on gl.id = goalmax.id AND gl.goal_version = goalmax.max_version order by gl.id;";
-        values = [ workspaceId ];
+        values = [ workspaceId, ownerId ];
     }
     else {
         // default to only retreiving active topics
-        text = "select * from goals gl INNER JOIN (SELECT id, MAX(goal_version) AS max_version FROM goals where active = $1 AND id = $2 group by id) goalmax "
+        text = "select * from goals gl INNER JOIN (SELECT id, MAX(goal_version) AS max_version FROM goals where active = $1 AND id = $2 AND (owned_by = $3 OR visibility = 2) group by id) goalmax "
         + "on gl.id = goalmax.id AND gl.goal_version = goalmax.max_version order by gl.id;";
-        values = [ true, workspaceId ];
+        values = [ true, workspaceId, ownerId ];
     }
 
 


### PR DESCRIPTION
Currently, the routes for workspace and topic getById was returning the object even if it were owned by another user and private. Adding a visibility check in the service layer and passing in the authUserId from the controller mitigates this.